### PR TITLE
Chiarimento su relazioni

### DIFF
--- a/logica.tex
+++ b/logica.tex
@@ -701,7 +701,7 @@ non è altro che un sottoinsieme del prodotto cartesiano: $R\subset A \times B$.
 Scriveremo $x R y$ quando $(x,y) \in R$.
 Ad esempio su un insieme di numeri potremmo considerare come $R$ la relazione d'ordine
 $\le$ per cui scriveremo $x \le y$ quando $(x,y)\in R$.
-Le relazioni possono eventualmente avere particolari caratteristiche
+Le relazioni da un insieme in sé stesso possono eventualmente avere particolari caratteristiche
 come essere: \emph{transitive} ($xRy \wedge yR z \implies x R z$),
 \emph{simmetriche} ($xRy \implies yRx$),
 \emph{riflessive} ($xRx$).


### PR DESCRIPTION
Chiarificato il fatto che le proprietà riflessiva, simmetrica e transitiva sono definite solo su relazioni tra da un insieme a sé stesso