### PR TITLE
Corretti alcuni piccoli errori sparsi nel file sulle successioni

### DIFF
--- a/AnalisiUno-successioni.tex_
+++ b/AnalisiUno-successioni.tex_
@@ -830,7 +830,7 @@ $b_k = a_{n_k}$ si dice essere una \myemph{sottosuccessione} di $a_n$
 \end{definition}
 
 Ricordando che una successione $a_n$ non è altro che una funzione
-$a\colon \NN \to \NN$, la successione $n_k$ corrisponde ad una funzione
+$a\colon \NN \to \RR$, la successione $n_k$ corrisponde ad una funzione
 $n\colon \NN \to \NN$ e la sottosuccessione $a_{n_k}$ corrisponde alla funzione composta $a \circ n$.
 
 Si osservi che nella definizione precedente la variabile $n$ rappresenta
@@ -1146,12 +1146,12 @@ in quanto se $a\in A_x$ e $b\in B_x$ allora $a<x<b$ e quindi $f(a)\le f(x) \le f
 
 Supponiamo che $f$ sia continua e consideriamo un
 qualunque $x\in I$.
-Se $x\neq \inf I$ dobbiamo mostrare che $f(A_x)\ge f(x)$.
+Se $x\neq \inf I$ dobbiamo mostrare che $\sup f(A_x)\ge f(x)$.
 La successione $x_n = x - 1/n$ sta in $A_x$ per $n$
-sufficientemente grande, dunque $\sup A_x \ge f(x_n)$.
-Ma visto che $f(x_n)\to f(x)$ per confronto si ottiene $\sup A_x \ge f(x)$.
+sufficientemente grande, dunque $\sup f(A_x) \ge f(x_n)$.
+Ma visto che $f(x_n)\to f(x)$ per confronto si ottiene $\sup f(A_x) \ge f(x)$.
 Analogamente se $x\neq \sup I$ prendendo la successione $x_n = x+1/n$
-si trova che $\inf B_x \le f(x)$. Dunque $\sup f(A_x) = f(x) = \inf f(B_x)$ come volevamo dimostrare.
+si trova che $\inf f(B_x) \le f(x)$. Dunque $\sup f(A_x) = f(x) = \inf f(B_x)$ come volevamo dimostrare.
 
 Supponiamo ora di sapere che
 per ogni $x \in I$, tolti gli estremi di $I$, si abbia
@@ -1445,8 +1445,8 @@ Definiamo ora
   \\
   B_x &= \{t\in \QQ\colon t>x\} = \QQ \cap (x,+\infty).
 \end{align*}
-Ovviamente $A_x < x < B_x$ (nel senso che per ogni $\alpha \in A$
-e per ogni $\beta \in B$ si ha $\alpha < x < \beta$).
+Ovviamente $A_x < x < B_x$ (nel senso che per ogni $\alpha \in A_x$
+e per ogni $\beta \in B_x$ si ha $\alpha < x < \beta$).
 Se vogliamo che $f$ sia crescente si dovrà quindi avere
 $f(A_x) \le f(x) \le f(B_x)$ da cui in particolare
 $\sup f(A_x) \le f(x) \le \inf f(B_x)$.
@@ -1476,13 +1476,13 @@ e tali che $z-y< \frac 1 n$. Allora si avrà
 \end{align*}
 Chiaramente $y\in A_x$ e $z\in B_x$ dunque
 \[
-\inf B_x - \sup A_x \le f(z) - f(y) \le f(k) \cdot (f(1/n)-1).
+\inf f(B_x) - \sup f(A_x) \le f(z) - f(y) \le f(k) \cdot (f(1/n)-1).
 \]
 Ricordiamo ora che $f(1/n) = \sqrt[n]{a} \to 1$ (teorema precedente)
 dunque il lato destro della precedente disuguaglianza può essere reso
 minore di qualunque $\eps>0$
 e quindi, come voluto,
-dovrà essere $\inf B_x = \sup A_x$.
+dovrà essere $\inf f(B_x) = \sup f(A_x)$.
 
 Mostriamo ora che $f(x)$ deve essere strettamente crescente su tutto $\RR$,
 ricordando


### PR DESCRIPTION
Riga 833: Successione è funzione da N a R, non da N a N;
Righe 1149-1154: Corretto, mancava un sup e alcuni A_x e B_x sarebbeo dovuti essere f(A_x) e f(B_x);
Righe 1448-1449: Aggiunti i pedici x ai nomi degli insiemi;
Righe 1479 e 1485: Corretto, alcuni A_x e B_x sarebbeo dovuti essere f(A_x) e f(B_x);