### PR TITLE
Corretti piccoli errori nella parte sulle serie

### DIFF
--- a/AnalisiUno-serie.tex_
+++ b/AnalisiUno-serie.tex_
@@ -846,7 +846,7 @@ Sia $\sum a_k$ una serie convergente ma non assolutamente convergente.
 Allora fissato qualunque $x \in [-\infty , +\infty]$ esiste un riordinamento
 $\sigma \colon \NN \to \NN$ tale che
 \[
-  \sum_{k=0}^+\infty  a_{\sigma(k)} = x.
+  \sum_{k=0}^{+\infty}  a_{\sigma(k)} = x.
 \]
 \end{theorem}
 %
@@ -875,7 +875,7 @@ Siano $a_k$ e $B_k$ successioni. Posto
 \]
 si ha
 \[
- \sum_{k=m}^n a_k B_k = A_{n+1} B_{n+1} - A_n B_n + \sum_{k=m}^n A_{k+1}(B_k - B_{k+1}).
+ \sum_{k=m}^n a_k B_k = A_{n+1} B_{n+1} - A_m B_m + \sum_{k=m}^n A_{k+1}(B_k - B_{k+1}).
 \]
 \end{theorem}
 %
@@ -899,7 +899,7 @@ Sommando si ottiene
 \sum_{k=m}^n a_k B_k
  &= \sum_{k=m}^n A_{k+1} B_{k+1} - \sum_{k=m}^n A_k B_k
      + \sum_{k=m}^n A_{k+1}(B_k - B_{k+1}) \\
- &= A_{n+1} B_{n+1} - A_n B_n + \sum_{k=m^n} A_{k+1}(B_k - B_{k+1}).
+ &= A_{n+1} B_{n+1} - A_m B_m + \sum_{k=m}^n A_{k+1}(B_k - B_{k+1}).
 \end{align*}
 \end{proof}
 
@@ -1133,12 +1133,12 @@ Ma allora
 &= \abs{\sum_{k=0}^{+\infty} a_k z_n^k - \sum_{k=0}^\infty a_k z^k}
 = \abs{\sum_{k=0}^{+\infty} a_k (z_n^k - z^k)} \\
 &\le \sum_{k=0}^{+\infty} \abs{a_k} \cdot \abs{z_n^k - z^k}
-\le \sum_{k=0}^{+\infty} \abs{a_k} \cdot \abs{z_k - z} k \rho^{k-1}\\
-&= \abs{z_k -z}\cdot \sum_{k=0}^{+\infty} k \abs{a_k} \rho^{k-1}.
+\le \sum_{k=0}^{+\infty} \abs{a_k} \cdot \abs{z_n - z} k \rho^{k-1}\\
+&= \abs{z_n -z}\cdot \sum_{k=0}^{+\infty} k \abs{a_k} \rho^{k-1}.
 \end{align*}
 
 Per il teorema precedente sappiamo che la serie $\sum k a_k \rho^{k-1}$
-è assolutamente convergente, dunque se $\abs{z_k - z} \to 0$ anche il lato
+è assolutamente convergente, dunque se $\abs{z_n - z} \to 0$ anche il lato
 destro della precedente disuguaglianza tende a zero e quindi,
 come volevamo dimostrare $f(z_n)-f(z) \to 0$.
 \end{proof}
@@ -1159,7 +1159,7 @@ e dunque l'insieme di convergenza è $A=\CC$.
 Vedremo in questo capitolo che la definizione data sopra coincide con
 la definizione di esponenziale
 \[
-e^z = \lim_{n\to +\infty}\enclose{1 + \frac 1 n}^n
+e^z = \lim_{n\to +\infty}\enclose{1 + \frac z n}^n
 \]
 data nel capitolo sui numeri complessi che a sua volta coincide con
 la potenza $e^x$ definita nel capitolo sui numeri reali.
@@ -1190,8 +1190,8 @@ Posto per ogni $k\le n$
 \begin{align*}
  c(n,k)
   &= \frac{n!}{n^k\cdot (n-k)!}
-  = \frac{n \cdot (n-1) \cdot \ldots \cdot(n-k)}{n^k} \\
-  &= \frac{n}{n}\cdot {\frac {n-1} n} \cdot \frac {n-2} {n} \cdot \ldots \cdot \frac{n-k}{n}
+  = \frac{n \cdot (n-1) \cdot \ldots \cdot(n-k+1)}{n^k} \\
+  &= \frac{n}{n}\cdot {\frac {n-1} n} \cdot \frac {n-2} {n} \cdot \ldots \cdot \frac{n-k+1}{n}
 \end{align*}
 osserviamo che $0\le c(n,k)\le 1$ in quanto
 prodotto di numeri non negativi minori o uguali ad $1$.


### PR DESCRIPTION
Riga 849: Aggiunte parentesi graffe mancanti, in modo che il simbolo di infinito sia correttamente posizionato
Riga 878 e 902: Corretti i pedici del secondo termine nella somma per parti
Riga 902: Spostata una parentesi graffa mal poszionata
Righe 1136 - 1137 e 1141: Corretto un pedice che si era trasformato da n a k
Riga 1162: Corretta la definizione di esponenziale
Righe 1193 - 1194: Corretto, il prodotto si ferma a n-k+1, non a n-k