### PR TITLE
Patch 8

### DIFF
--- a/AnalisiUno-integrali.tex_
+++ b/AnalisiUno-integrali.tex_
@@ -95,7 +95,7 @@ per cui si ha
 \end{equation*}
 allora la funzione $f$ è Riemann-integrabile e si ha
 \[
-  \int_a^b f(x)\, dx = \lim_{n\to+\infty} S*(f,P_n) = \lim_{n\to+\infty} S_*(f,P_n).
+  \int_a^b f(x)\, dx = \lim_{n\to+\infty} S^*(f,P_n) = \lim_{n\to+\infty} S_*(f,P_n).
 \]
 \end{enumerate}
 \end{theorem}
@@ -935,7 +935,7 @@ utilizzando il punto precedente sappiamo però che vale
 \[
 F(x) - F(g(a)) =
 \int_a^{g^{-1}(x)} f(g(t)) g'(t)\, dt
-= \int_{g(a)} x f(t)\, dt.
+= \int_{g(a)}^x f(t)\, dt.
 \]
 Dunque derivando ambo i membri, grazie ancora al teorema
 fondamentale otteniamo:
@@ -1372,7 +1372,7 @@ Si ha
 %
 \begin{proof}
 Osserviamo in generale che se $f:[a,b]\to \RR$ è una funzione concava allora il grafico di $f$ è compreso tra la retta passante per gli estremi $(a,f(a))$, $(b,f(b))$ (retta secante) e una qualunque retta tangente, ad esempio la retta tangente in $((a+b)/2,f((a+b)/2))$.
-Di conseguenza l'area sotto il grafico, cioè $\int_a^b f(x)\, dx$ è compreso tra le aree dei due corrispondenti trapezi rettangoli. L'altezza di entrambi i trapezi è pari a $(b-a)$ e l'area si calcola moltiplicando l'altezza per la media delle basi. Nel caso del trapezio con lato obliquo la secante la media delle basi è $(f(a)+f(b))/2$, nel caso del trapezio con lato obliquo sulla retta tangente nel punto medio, la media delle basi è uguale alla sezione nel punto medio: $(f(a+b)/2)$. Si ottiene dunque,
+Di conseguenza l'area sotto il grafico, cioè $\int_a^b f(x)\, dx$ è compreso tra le aree dei due corrispondenti trapezi rettangoli. L'altezza di entrambi i trapezi è pari a $(b-a)$ e l'area si calcola moltiplicando l'altezza per la media delle basi. Nel caso del trapezio con lato obliquo la secante la media delle basi è $(f(a)+f(b))/2$, nel caso del trapezio con lato obliquo sulla retta tangente nel punto medio, la media delle basi è uguale alla sezione nel punto medio: $f((a+b)/2)$. Si ottiene dunque,
 per ogni $f$ concava,
 \[
    (b-a)\cdot  \frac{f(a) + f(b)}{2}
@@ -1541,7 +1541,7 @@ dove
 
 Guardando il lato sinistro dell'uguaglianza \eqref{eq:43775} vediamo una combinazione lineare con coefficienti $A_{kj}$ di fratti semplici e per la prima parte del teorema sappiamo che lo spazio $V$ di tutte le funzioni che
 si possono ottenere mediante tali combinazioni è un
-sottospazio vettoriale di dimensione $N$ di $\RR^\Omega$.
+sottospazio vettoriale di dimensione $N$ di $\CC^\Omega$.
 
 Guardando il lato destro vediamo che al "numeratore" c'è
 invece una combinazione di polinomi $S_{kj}$ ognuno dei quali ha grado inferiore ad $N$. Quello che si ottiene è dunque un polinomio di grado inferiore ad $N$. Al denominatore c'è il polinomio fissato $Q$. Dunque al variare dei coefficienti $A_{kj}$ il lato destro è un sottospazio dello spazio dei polinomi di grado inferiore ad $N$ che vengono poi divisi per $Q$. Anche questo spazio ha dimensione $N$ (in quanto di polinomi di grado $N-1$ sono combinazione lineare dei monomi $1, z, z^2, \dots, z^{N-1}$) e contiene lo spazio $V$ che pure abbiamo verificato avere dimensione $N$. Dunque i due spazi coincidono e questo significa che il polinomio $P$, avendo grado inferiore ad $N$ è combinazione lineare dei polinomi $S_{kj}$ per una opportuna (unica) scelta dei coefficienti $A_{kj}$.
@@ -1936,7 +1936,7 @@ Dunque la formula fondamentale del calcolo integrale è formalmente identica per
 La funzione $\ln x$ è integrabile in senso improprio sull'intervallo $(0,+\infty)$ in quanto si ha:
 \begin{align*}
  \int_0^{+\infty}\ln x \, dx
- &= \Enclose{x \ln x }_0^{+\infty}
+ &= \Enclose{x \ln x - x}_0^{+\infty}
  = +\infty
 \end{align*}
 \end{example}
@@ -1973,7 +1973,7 @@ sull'intervallo $(0,+\infty)$ in quanto si ha
 \[
   \int_0^{+\infty} \frac{1}{x}\, dx
   = \Enclose{\ln x}_0^{+\infty}
-  = 0 - (-\infty) = +\infty.
+  = +\infty - (-\infty) = +\infty.
 \]
 Analogamente tale funzione è integrabile in senso improprio su $(-\infty,0)$ e si ha
 \[

--- a/AnalisiUno-integrali.tex_
+++ b/AnalisiUno-integrali.tex_
@@ -2099,7 +2099,7 @@ La verifica si fa facilmente valutando il limite della primitiva $F(x) = x^{1-p}
 Si determini per quali $\alpha,\beta\in \RR$ risultano convergenti
 gli integrali:
 \[
-  \int_0^{\frac 1 2} \frac{1}{x^\alpha \ln^\beta x}\, dx,
+  \int_0^{\frac 1 2} \frac{1}{x^\alpha \abs{ln x}^\beta}\, dx,
   \qquad
   \int_2^{+\infty} \frac{1}{x^\alpha \ln^\beta x} \, dx.
 \]


### PR DESCRIPTION
Corretto typo nei criteri di integrabilità, nel cambio di variabile negli integrali, in Stirling, nella decomposizione complessa in fratti semplici, negli esempi sull'integrabilità in senso improprio di ln x e 1/x
Aggiunto modulo al logaritmo in un esercizio in cui, avendo argomento <1, è negativo